### PR TITLE
Make Mocka Thread Safe

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -16,6 +16,11 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+      
+    - name: Run linting with Revive
+      uses: morphy2k/revive-action@v1.3.1
+      with:
+        config: revive.toml
 
     - name: Run tests
       run: go test ./... -v -cover

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,9 +9,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Revive for linting Go code
 - Dlv for debugging Go code
 - Additional nil checks to prevent internal panics
+- Mutex to sandbox
+- RWMutex to mockFunction
 
 ### Changed
 - Examples to have more use cases
+- Sandbox to use pointer to stubs to not copy mutex value
 
 ### Fixed
 - Equality checks in WithArgs to use reflect.DeepEqual to compare slices

--- a/customArguments.go
+++ b/customArguments.go
@@ -16,6 +16,9 @@ func (ca *customArguments) Return(returnValues ...interface{}) error {
 		return errors.New("mocka: stub does not exist")
 	}
 
+	ca.stub.lock.Lock()
+	defer ca.stub.lock.Unlock()
+
 	if !validateOutParameters(ca.stub.toType(), returnValues) {
 		return &outParameterValidationError{ca.stub.toType(), returnValues}
 	}
@@ -32,6 +35,12 @@ func (ca *customArguments) Return(returnValues ...interface{}) error {
 // return values based on the call index for this specific set
 // of custom arguments.
 func (ca *customArguments) OnCall(callIndex int) Returner {
+	// TODO - future story
+	// validate stub exists before using .lock
+	// change return to also return an error if stub does not exist
+	ca.stub.lock.Lock()
+	defer ca.stub.lock.Unlock()
+
 	for _, o := range ca.onCalls {
 		if o.index == callIndex {
 			return o

--- a/onCall.go
+++ b/onCall.go
@@ -22,6 +22,9 @@ func (c *onCall) Return(returnValues ...interface{}) error {
 		return errors.New("mocka: stub does not exist")
 	}
 
+	c.stub.lock.Lock()
+	defer c.stub.lock.Unlock()
+
 	if !validateOutParameters(c.stub.toType(), returnValues) {
 		return &outParameterValidationError{c.stub.toType(), returnValues}
 	}

--- a/sandbox_test.go
+++ b/sandbox_test.go
@@ -17,7 +17,7 @@ var _ = Describe("sandbox", func() {
 	)
 
 	BeforeEach(func() {
-		testSandbox = &sandbox{nil}
+		testSandbox = &sandbox{}
 		callCounts = map[string]int{"fn1": 0, "fn2": 0, "fn3": 0}
 		fn1 = func(str string, num int) (int, error) {
 			callCounts["fn1"]++


### PR DESCRIPTION
## Added
- Mutex to sandboxes
- RWMutex to mockFunction
- **TODO** to be resolved in future story when `mocka` is bumped to v2
  - _Requires public API changes_

## Changed
- Sandboxes now use pointers to stub to not copy mutex values

## Linked Issues
- #7 