### PR TITLE
Deprecate mocka.File()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
-## [Deprecated]
+## Deprecated
 - mocka.File() - it is recommended to refactor code to use io interfaces over file based mocks
 
 ## [1.1.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+## [Deprecated]
+- mocka.File() - it is recommended to refactor code to use io interfaces over file based mocks
 
 ## [1.1.0]
 ## Added

--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ type Stub interface {
 
 ## Mocking Files
 
-> Deprecated: mocka.File() has not completely worked since go 1.13.x was released. File mocks will be removed in version 2. It is recommend to refactor to use oi interfaces over file based mocks.
+> Deprecated: mocka.File() has not completely worked since go 1.13.x was released. File mocks will be removed in version 2. It is recommend to refactor to use io interfaces over file based mocks.
 
 `mocka.File` returns a structure that can be used to mock a `os.File` in Go. In order to be able to mock a `os.File` this structure implements the following interface:
 

--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ type Stub interface {
 
 ## Mocking Files
 
+> Deprecated: mocka.File() has not completely worked since go 1.13.x was released. File mocks will be removed in version 2. It is recommend to refactor to use oi interfaces over file based mocks.
+
 `mocka.File` returns a structure that can be used to mock a `os.File` in Go. In order to be able to mock a `os.File` this structure implements the following interface:
 
 ```go

--- a/examples/mocka_test.go
+++ b/examples/mocka_test.go
@@ -14,7 +14,9 @@ func ExampleFile() {
 	f.Read(b)
 
 	fmt.Println(string(b))
-	// Output: This is the body
+	// Output:
+	// mocka.File() is deprecated and will be removed in v2. It is recommended to refactor to use io interfaces over file based mocks.
+	// This is the body
 }
 
 func ExampleFunction() {

--- a/mocka.go
+++ b/mocka.go
@@ -33,6 +33,7 @@
 package mocka
 
 import (
+	"fmt"
 	"io"
 )
 
@@ -48,7 +49,12 @@ import (
 //
 // The mock file should be able to be used in place of any implementation
 // that requires an os.File.
+//
+// Deprecated: mocka.File() has not completely worked since go 1.13.x was
+// released. File mocks will be removed in version 2. It is recommend
+// to refactor to use oi interfaces over file based mocks.
 func File(name string, body string) io.ReadWriteCloser {
+	fmt.Println("\nmocka.File() is deprecated and will be removed in v2. It is recommended to refactor to use io interfaces over file based mocks.")
 	return &mockFile{name: name, buf: []byte(body), offset: 0, base: 0, limit: int64(len(body))}
 }
 


### PR DESCRIPTION
## Deprecated
- `mocka.File()` - it is recommended to refactor code to use io interfaces over file based mocks.

